### PR TITLE
fix: Optimize join order based on table size in estimateTableSize fun…

### DIFF
--- a/src/main/scala/org/grapheco/lynx/optimizer/JoinTableSizeEstimateRule.scala
+++ b/src/main/scala/org/grapheco/lynx/optimizer/JoinTableSizeEstimateRule.scala
@@ -71,7 +71,7 @@ object JoinTableSizeEstimateRule extends PhysicalPlanOptimizerRule {
     val estimateTable1 = estimate(table1, ppc)
     val estimateTable2 = estimate(table2, ppc)
     if (estimateTable1 <= estimateTable2) Join(parent.filterExpr, parent.isSingleMatch, parent.joinType)(table1, table2, ppc)
-    else Join(parent.filterExpr, parent.isSingleMatch, parent.joinType)(table1, table2, ppc)
+    else Join(parent.filterExpr, parent.isSingleMatch, parent.joinType)(table2, table1, ppc)
   }
 
   def joinRecursion(parent: Join, ppc: PhysicalPlannerContext, isSingleMatch: Boolean): PhysicalPlan = {


### PR DESCRIPTION
if (estimateTable1 <= estimateTable2) Join(parent.filterExpr, parent.isSingleMatch, parent.joinType)(table1, table2, ppc)
else Join(parent.filterExpr, parent.isSingleMatch, parent.joinType)(table1, table2, ppc)

这里将 estimateTable1 和 estimateTable2 进行比较，应该是想将较小的表作为左表，较大表作为右表，但if-else代码中逻辑相同，故修改为正确逻辑。