### PR TITLE
Lynx list

### DIFF
--- a/member/zsj.json
+++ b/member/zsj.json
@@ -1,0 +1,4 @@
+{
+  "name": "周士浚",
+  "url": "https://github.com/damieqqq1"
+}

--- a/src/main/scala/org/grapheco/lynx/types/composite/LynxList.scala
+++ b/src/main/scala/org/grapheco/lynx/types/composite/LynxList.scala
@@ -1,51 +1,76 @@
+
 package org.grapheco.lynx.types.composite
 
 import org.grapheco.lynx.types._
 import org.grapheco.lynx.types.property.{LynxFloat, LynxInteger, LynxNull, LynxNumber, LynxString}
 
 /**
- * @ClassName LynxList
- * @Description TODO
- * @Author huchuan
- * @Date 2022/4/1
- * @Version 0.1
+ * Represents a list of LynxValue in the Lynx graph database.
+ * @param v The list of LynxValue elements.
  */
-case class LynxList(v: List[LynxValue]) extends LynxCompositeValue {
+case class LynxList private (v: List[LynxValue]) extends LynxCompositeValue {
+
+  /**
+   * Returns the underlying list of LynxValue elements.
+   */
   override def value: List[LynxValue] = v
 
+  /**
+   * Returns the type of this LynxList, which is a list of any type (LTAny).
+   */
   override def lynxType: ListType = LTList(LTAny)
 
-  /*
-  Lists are compared in dictionary order, i.e. list elements are compared pairwise in
-  ascending order from the start of the list to the end. Elements missing in a shorter list are
-  considered to be less than any other value (including null values). For example, [1] < [1, 0]
-  but also [1] < [1, null].
-  • If comparing two lists requires comparing at least a single null value to some other value,
-  these lists are incomparable. For example, [1, 2] >= [1, null] evaluates to null.
-  • Lists are incomparable to any value that is not also a list.
+  /**
+   * Compares this LynxList with another LynxValue in dictionary order.
+   * @param o The LynxValue to compare with.
+   * @return An integer indicating the comparison result.
    */
   override def sameTypeCompareTo(o: LynxValue): Int = o match {
     case l: LynxList =>
-      val iter_x = this.value.iterator
-      val iter_y = l.value.iterator
-      while (iter_x.hasNext && iter_y.hasNext) {
-        val elementCompared = iter_x.next().compareTo(iter_y.next())
-        if (elementCompared != 0) return elementCompared
-      }
-      (iter_x.hasNext, iter_y.hasNext) match {
-        case (true, false) => 1
-        case (false, true) => -1
-        case (false, false) => 0
-      }
-    case _ => throw TypeMismatchException(this.lynxType, o.lynxType)
+      compareLists(this.value, l.value)
+    case _ =>
+      throw TypeMismatchException(this.lynxType, o.lynxType)
   }
 
-  lazy val droppedNull: Seq[LynxValue] = v.filterNot(LynxNull.equals)
+  /**
+   * Filters out LynxNull values from the list.
+   */
+  lazy val droppedNull: Seq[LynxValue] = v.filterNot(_ == LynxNull)
 
-  def map(f: LynxValue => LynxValue): LynxList = LynxList(this.v.map(f))
+  /**
+   * Applies a function to each element of the list and returns a new LynxList.
+   * @param f The function to apply.
+   * @return A new LynxList with the function applied to each element.
+   */
+  def map(f: LynxValue => LynxValue): LynxList = LynxList(v.map(f))
 
-
+  /**
+   * Finds the minimum LynxValue in the list, excluding LynxNull values.
+   * @return The minimum LynxValue or LynxNull if the list is empty.
+   */
   def min: LynxValue = if (droppedNull.isEmpty) LynxNull else droppedNull.min
 
+  /**
+   * Finds the maximum LynxValue in the list, excluding LynxNull values.
+   * @return The maximum LynxValue or LynxNull if the list is empty.
+   */
   def max: LynxValue = if (droppedNull.isEmpty) LynxNull else droppedNull.max
+
+  /**
+   * Helper method to compare two lists in dictionary order.
+   */
+  private def compareLists(list1: List[LynxValue], list2: List[LynxValue]): Int = {
+    val iter1 = list1.iterator
+    val iter2 = list2.iterator
+    while (iter1.hasNext && iter2.hasNext) {
+      val compared = iter1.next().compareTo(iter2.next())
+      if (compared != 0) return compared
+    }
+    (iter1.hasNext, iter2.hasNext) match {
+      case (true, false) => 1
+      case (false, true) => -1
+      case (false, false) => 0
+    }
+  }
 }
+


### PR DESCRIPTION
alter（LynxList.scala）:
Private Constructor: The constructor of LynxList is made private to ensure that instances can only be created through the LynxList class itself, which helps to better control the creation of instances.

Clear Documentation Comments: Detailed documentation comments have been added for each method to improve the readability and maintainability of the code.

Helper Method: The list comparison logic has been extracted into a private helper method named compareLists to keep the code clean and modular.

Code Style: Some adjustments have been made to the code style to conform to Scala's coding conventions.
