### PR TITLE
Optimized ApplyPushDownRule, LynxRecord and JoinTableSizeEstimateRule

### DIFF
--- a/src/main/scala/org/grapheco/lynx/LynxRecord.scala
+++ b/src/main/scala/org/grapheco/lynx/LynxRecord.scala
@@ -3,25 +3,67 @@ package org.grapheco.lynx
 import org.grapheco.lynx.types.LynxValue
 import org.grapheco.lynx.types.property.{LynxBoolean, LynxFloat, LynxInteger, LynxNull, LynxString}
 import org.grapheco.lynx.types.structural.{LynxNode, LynxRelationship}
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger(classOf[LynxRecord])
 
 case class LynxRecord(cols: Map[String, Int], values: Seq[LynxValue]){
   def apply(columnName: String): LynxValue = get(columnName).getOrElse(LynxNull)
 
-  def get(columnName: String): Option[LynxValue] = cols.get(columnName).map(values.apply)
+ def get(columnName: String): Option[LynxValue] = {
+  val result = cols.get(columnName).map(values.apply)
+  if (result.isEmpty) logger.debug(s"Column '$columnName' not found.")
+  result
+}
 
   def get(columnIndex: Int): Option[LynxValue] = values.lift(columnIndex)
 
-  def getAsString(columnName: String): Option[LynxString] = get(columnName).map(_.asInstanceOf[LynxString])
+def getAsString(columnName: String): Option[LynxString] = get(columnName) match {
+  case Some(value: LynxString) => Some(value)
+  case _ => None
+}
 
-  def getAsInt(columnName: String): Option[LynxInteger] = get(columnName).map(_.asInstanceOf[LynxInteger])
+def getAsDate(columnName: String): Option[LynxDate] = get(columnName) match {
+  case Some(value: LynxDate) => Some(value)
+  case _ => None
+}
 
-  def getAsDouble(columnName: String): Option[LynxFloat] = get(columnName).map(_.asInstanceOf[LynxFloat])
+def getAsList(columnName: String): Option[Seq[LynxValue]] = get(columnName) match {
+  case Some(value: LynxList) => Some(value.elements)
+  case _ => None
+}
 
-  def getAsBoolean(columnName: String): Option[LynxBoolean] = get(columnName).map(_.asInstanceOf[LynxBoolean])
+def getAsInt(columnName: String): Option[LynxInteger] = get(columnName) match {
+  case Some(value: LynxInteger) => Some(value)
+  case _ => None
+}
 
-  def getAsNode(columnName: String): Option[LynxNode] = get(columnName).map(_.asInstanceOf[LynxNode])
+  def getAsDouble(columnName: String): Option[LynxFloat] = get(columnName)  match {
+  case Some(value: LynxFloat) => Some(value)
+  case _ => None
+}
 
-  def getAsRelationship(columnName: String): Option[LynxRelationship] = get(columnName).map(_.asInstanceOf[LynxRelationship])
+  def getAsBoolean(columnName: String): Option[LynxBoolean] = get(columnName)  match {
+  case Some(value:LynxBoolean) => Some(value)
+  case _ => None
+}
 
-  def toMap: Map[String, LynxValue] = cols.keys.zip(values).toMap
+  def getAsNode(columnName: String): Option[LynxNode] = get(columnName)  match {
+  case Some(value:LynxNode) => Some(value)
+  case _ => None
+}
+
+  def getAsRelationship(columnName: String): Option[LynxRelationship] = get(columnName)  match {
+  case Some(value:LynxRelationship) => Some(value)
+  case _ => None
+}
+
+def getIgnoreCase(columnName: String): Option[LynxValue] = {
+  cols.find { case (key, _) => key.equalsIgnoreCase(columnName) }
+      .flatMap { case (_, index) => values.lift(index) }
+}
+
+  def toMap: Map[String, LynxValue] = cols.map { case (key, index) =>
+  key -> values.lift(index).getOrElse(LynxNull)
+}
 }

--- a/src/main/scala/org/grapheco/lynx/optimizer/ApplyPushDownRule.scala
+++ b/src/main/scala/org/grapheco/lynx/optimizer/ApplyPushDownRule.scala
@@ -19,7 +19,8 @@ object ApplyPushDownRule extends PhysicalPlanOptimizerRule {
       ║
      [A]
      */
-    case apply: Apply => apply
+    // case apply: Apply => apply
+    case apply: Apply if apply.right.isEmpty => apply.left
   }
 
   private val APPLY_PUSH_DOWN: PartialFunction[PhysicalPlan, PhysicalPlan] = {
@@ -38,7 +39,8 @@ object ApplyPushDownRule extends PhysicalPlanOptimizerRule {
     case apply:Apply =>
       val A = apply.left
       val B = apply.right
-      val returnItemNames = A.get.schema.map(_._1)
+      // val returnItemNames = A.get.schema.map(_._1)
+      val returnItemNames = A.get.schema.map(_._1).toSet
 
       while (apply.right.isDefined
 //        && apply.right.get.children.length==1

--- a/src/main/scala/org/grapheco/lynx/procedure/LogarithmicFunctions.scala
+++ b/src/main/scala/org/grapheco/lynx/procedure/LogarithmicFunctions.scala
@@ -41,4 +41,9 @@ class LogarithmicFunctions {
   def sqrt(x: LynxNumber): Double = {
     math.sqrt(x.number.doubleValue())
   }
+
+  @LynxProcedure(name = "power")
+  def power(x: LynxInteger, n: LynxInteger): Int = {
+    math.pow(x.value, n.value).toInt
+  }
 }

--- a/src/main/scala/org/grapheco/lynx/procedure/NumericFunctions.scala
+++ b/src/main/scala/org/grapheco/lynx/procedure/NumericFunctions.scala
@@ -50,4 +50,15 @@ class NumericFunctions {
   def sign(x: LynxNumber): Double = {
     math.signum(x.number.doubleValue())
   }
+
+  @LynxProcedure(name = "trunc")
+  def trunc(x: LynxNumber, precision: Option[LynxNumber] = None): Double = {
+    precision match {
+      case Some(p) =>
+        val scale = math.pow(10, p.number.doubleValue()).toDouble
+        math.floor(x.number.doubleValue() * scale) / scale
+      case None =>
+        if (x.number.doubleValue() >= 0) math.floor(x.number.doubleValue()) else math.ceil(x.number.doubleValue())
+    }
+  }
 }

--- a/src/main/scala/org/grapheco/lynx/procedure/TrigonometricFunctions.scala
+++ b/src/main/scala/org/grapheco/lynx/procedure/TrigonometricFunctions.scala
@@ -87,4 +87,14 @@ class TrigonometricFunctions {
   def tanh(x: LynxNumber): Double = {
     math.tanh(x.number.doubleValue())
   }
+
+  @LynxProcedure(name = "degrees")
+  def degrees(x: LynxNumber): Double = {
+    math.toDegrees(x.number.doubleValue())
+  }
+
+  @LynxProcedure(name = "radians")
+  def radians(x: LynxNumber): Double = {
+    math.toRadians(x.number.doubleValue())
+  }
 }


### PR DESCRIPTION
成员1：wx
分工：尝试优化ApplyPushDownRule.scala，额外提出了几个函数
具体改动内容：
（1）在ApplyPushDownRule.scala，添加了 if apply.right.isEmpty 条件，直接判断 Apply 节点是否无效，简化了移除逻辑，同时修改了val returnItemNames = A.schema.map(_._1).toSet，因为如果 A.schema 包含大量字段，Set 的查找性能更优。
（2）将power函数从时间类函数中移到对数操作类函数中
（3）增加了对数据的截断函数trunc，支持可选参数指定保留的小数位数，默认截断到整数位；增加了弧度转化为角度的函数degrees；增加了角度转化为弧度的函数radians
成员2：lxy
分工：优化了LynxRecord中一些潜在问题。
具体优化内容：
（1）类型转换安全性：map(_.asInstanceOf[LynxX]) 中未进行类型检查，若类型不匹配，程序会抛出 异常，因此使用模式匹配方法，避免程序崩溃。
（2）toMap方法：使用 keys.zip(values)，若 cols.keys 和 values 的长度不一致，会导致抛出异常或数据丢失，因此修改为根据 cols 的映射来生成键值对。
（3）增加数据类型支持：除去文中提到的数据类型，还增加了date以及list两种数据类型供使用。
（4）去除列名大小写干扰：有时列名的大小写可能不一致，因此提供了一个大小写无关的访问选项getIgnoreCase（）。
（5）增加日志记录logger：当无法找到列名或发生错误时，记录日志以便排查问题。
成员3：lyx
分工：对 JoinTableSizeEstimateRule 进行了代码优化。
具体优化内容：
（1）apply方法:在apply方法内模式匹配方式不够简洁明了，后续如果需要扩展对其他类型节点的判断逻辑，容易使match代码块变得臃肿,因此新增了两个私有辅助方法，让apply方法内的模式匹配逻辑更清晰。
（2）estimateNodeRow方法：代码中有较多的嵌套match和比较复杂的类型判断及取值操作，使用collect方法来更简洁地处理属性提取部分，同时使用flatten方法将可能嵌套的结果扁平化处理。
（3）joinRecursion方法：代码中对于parent.children.head和parent.children.last的处理逻辑基本重复，,对此提取出了一个私有方法，将获取基础表的公共操作封装在一个私有方法。