### PR TITLE
add:HashJoiner.scala and JoinerSelector.scala

### DIFF
--- a/src/main/scala/org/grapheco/lynx/dataframe/DefaultDataFrameOperator.scala
+++ b/src/main/scala/org/grapheco/lynx/dataframe/DefaultDataFrameOperator.scala
@@ -74,7 +74,8 @@ class DefaultDataFrameOperator(expressionEvaluator: ExpressionEvaluator) extends
   override def take(df: DataFrame, num: Int): DataFrame = DataFrame(df.schema, () => df.records.take(num))
 
   override def join(a: DataFrame, b: DataFrame, joinColumns: Seq[String], joinType: JoinType): DataFrame = {
-    SortMergeJoiner.join(a, b, joinColumns, joinType)
+    // Select the connection algorithm based on heuristic rules
+    JoinerSelector.chooseJoin(a, b, joinColumns, joinType)
   }
 
   override def cross(a: DataFrame, b: DataFrame): DataFrame = {

--- a/src/main/scala/org/grapheco/lynx/dataframe/HashJoiner.scala
+++ b/src/main/scala/org/grapheco/lynx/dataframe/HashJoiner.scala
@@ -1,0 +1,134 @@
+package org.grapheco.lynx.dataframe
+
+import org.grapheco.lynx.types.{LynxType, LynxValue}
+import org.grapheco.lynx.types.property.LynxNull
+import org.grapheco.lynx.util.Profiler
+
+import scala.collection.mutable.{ListBuffer, HashMap}
+
+object HashJoiner {
+
+  def join(a: DataFrame, b: DataFrame, joinColumns: Seq[String], joinType: JoinType): DataFrame = {
+    val joinColIndexes: Seq[(Int, Int)] = joinColumns
+      .map(columnName =>
+        (a.columnsName.indexOf(columnName), b.columnsName.indexOf(columnName))
+      )
+
+    joinType match {
+      case InnerJoin => _innerJoin(a, b, joinColIndexes)
+      case OuterJoin => _fullOuterJoin(a, b, joinColIndexes)
+      case LeftJoin => _leftJoin(a, b, joinColIndexes)
+      case RightJoin => _rightJoin(a, b, joinColIndexes)
+      case _ => throw new Exception("Unexpected JoinType in DataFrame Join Function.")
+    }
+  }
+
+  private def _innerJoin(a: DataFrame, b: DataFrame, joinColIndexes: Seq[(Int, Int)]): DataFrame = {
+    val hashTableB: HashMap[Seq[LynxValue], ListBuffer[Seq[LynxValue]]] = _buildHashTable(b, joinColIndexes.map(_._2))
+
+    val joinedSchema: Seq[(String, LynxType)] = a.schema ++ b.schema
+    val joinedDataFrame: ListBuffer[Seq[LynxValue]] = ListBuffer[Seq[LynxValue]]()
+
+    for (rowA <- a.records) {
+      val joinKeyA: Seq[LynxValue] = joinColIndexes.map { case (aIndex, _) => rowA(aIndex) }
+      if (hashTableB.contains(joinKeyA)) {
+        hashTableB(joinKeyA).foreach { rowB =>
+          joinedDataFrame.append(rowA ++ rowB)
+        }
+      }
+    }
+
+    DataFrame(joinedSchema, () => joinedDataFrame.toIterator)
+  }
+
+  private def _fullOuterJoin(a: DataFrame, b: DataFrame, joinColIndexes: Seq[(Int, Int)]): DataFrame = {
+    val hashTableB: HashMap[Seq[LynxValue], ListBuffer[Seq[LynxValue]]] = _buildHashTable(b, joinColIndexes.map(_._2))
+
+    val joinedSchema: Seq[(String, LynxType)] = a.schema ++ b.schema
+    val joinedDataFrame: ListBuffer[Seq[LynxValue]] = ListBuffer[Seq[LynxValue]]()
+
+    for (rowA <- a.records) {
+      val joinKeyA: Seq[LynxValue] = joinColIndexes.map { case (aIndex, _) => rowA(aIndex) }
+      if (hashTableB.contains(joinKeyA)) {
+        hashTableB(joinKeyA).foreach { rowB =>
+          joinedDataFrame.append(rowA ++ rowB)
+        }
+      } else {
+        // No match in B, so append rowA with nulls for B's columns
+        joinedDataFrame.append(rowA ++ new Array[LynxValue](b.schema.length).map(_ => LynxNull))
+      }
+    }
+
+    // Add rows from B that don't have a match in A
+    for (rowB <- b.records) {
+      val joinKeyB: Seq[LynxValue] = joinColIndexes.map { case (_, bIndex) => rowB(bIndex) }
+      val matchingRowsInA = a.records.exists { rowA =>
+        val joinKeyA: Seq[LynxValue] = joinColIndexes.map { case (aIndex, _) => rowA(aIndex) }
+        joinKeyA == joinKeyB
+      }
+      if (!matchingRowsInA) {
+        // No match in A, so append rowB with nulls for A's columns
+        joinedDataFrame.append(new Array[LynxValue](a.schema.length).map(_ => LynxNull) ++ rowB)
+      }
+    }
+
+    DataFrame(joinedSchema, () => joinedDataFrame.toIterator)
+  }
+
+  private def _leftJoin(a: DataFrame, b: DataFrame, joinColIndexes: Seq[(Int, Int)]): DataFrame = {
+    val hashTableB: HashMap[Seq[LynxValue], ListBuffer[Seq[LynxValue]]] = _buildHashTable(b, joinColIndexes.map(_._2))
+
+    val joinedSchema: Seq[(String, LynxType)] = a.schema ++ b.schema
+    val joinedDataFrame: ListBuffer[Seq[LynxValue]] = ListBuffer[Seq[LynxValue]]()
+
+    for (rowA <- a.records) {
+      val joinKeyA: Seq[LynxValue] = joinColIndexes.map { case (aIndex, _) => rowA(aIndex) }
+      if (hashTableB.contains(joinKeyA)) {
+        hashTableB(joinKeyA).foreach { rowB =>
+          joinedDataFrame.append(rowA ++ rowB)
+        }
+      } else {
+        // No match in B, so append rowA with nulls for B's columns
+        joinedDataFrame.append(rowA ++ new Array[LynxValue](b.schema.length).map(_ => LynxNull))
+      }
+    }
+
+    DataFrame(joinedSchema, () => joinedDataFrame.toIterator)
+  }
+
+  private def _rightJoin(a: DataFrame, b: DataFrame, joinColIndexes: Seq[(Int, Int)]): DataFrame = {
+    val hashTableA: HashMap[Seq[LynxValue], ListBuffer[Seq[LynxValue]]] = _buildHashTable(a, joinColIndexes.map(_._1))
+
+    val joinedSchema: Seq[(String, LynxType)] = a.schema ++ b.schema
+    val joinedDataFrame: ListBuffer[Seq[LynxValue]] = ListBuffer[Seq[LynxValue]]()
+
+    for (rowB <- b.records) {
+      val joinKeyB: Seq[LynxValue] = joinColIndexes.map { case (_, bIndex) => rowB(bIndex) }
+      if (hashTableA.contains(joinKeyB)) {
+        hashTableA(joinKeyB).foreach { rowA =>
+          joinedDataFrame.append(rowA ++ rowB)
+        }
+      } else {
+        // No match in A, so append rowB with nulls for A's columns
+        joinedDataFrame.append(new Array[LynxValue](a.schema.length).map(_ => LynxNull) ++ rowB)
+      }
+    }
+
+    DataFrame(joinedSchema, () => joinedDataFrame.toIterator)
+  }
+
+  private def _buildHashTable(df: DataFrame, joinColIndexes: Seq[Int]): HashMap[Seq[LynxValue], ListBuffer[Seq[LynxValue]]] = {
+    val hashTable: HashMap[Seq[LynxValue], ListBuffer[Seq[LynxValue]]] = HashMap.empty
+
+    for (row <- df.records) {
+      val joinKey: Seq[LynxValue] = joinColIndexes.map(colIndex => row(colIndex))
+      if (!hashTable.contains(joinKey)) {
+        hashTable(joinKey) = ListBuffer[Seq[LynxValue]]()
+      }
+      hashTable(joinKey).append(row)
+    }
+
+    hashTable
+  }
+
+}

--- a/src/main/scala/org/grapheco/lynx/dataframe/JoinerSelector.scala
+++ b/src/main/scala/org/grapheco/lynx/dataframe/JoinerSelector.scala
@@ -1,0 +1,70 @@
+package org.grapheco.lynx.dataframe
+
+import org.grapheco.lynx.types.{LynxValue, LynxType}
+import org.grapheco.lynx.types.property.LynxNull
+
+object JoinerSelector {
+
+  /**
+   * Choose the appropriate joiner (SortMergeJoin or HashJoin) based on the input DataFrames.
+   *
+   * @param a The first DataFrame.
+   * @param b The second DataFrame.
+   * @param joinColumns The columns to join on.
+   * @param joinType The type of join (e.g., InnerJoin, LeftJoin, etc.).
+   * @return A function that performs the join using the appropriate joiner.
+   */
+  def chooseJoiner(a: DataFrame, b: DataFrame, joinColumns: Seq[String], joinType: JoinType): (DataFrame, DataFrame, Seq[String], JoinType) => DataFrame = {
+    // Check if the DataFrames should use SortMergeJoiner or HashJoiner based on heuristics
+    if (shouldUseSortMergeJoin(a, b, joinColumns)) {
+      // If both tables are sorted on the join columns, use SortMergeJoiner
+      (a: DataFrame, b: DataFrame, joinColumns: Seq[String], joinType: JoinType) => 
+        SortMergeJoiner.join(a, b, joinColumns, joinType)
+    } else {
+      // Otherwise, use HashJoiner
+      (a: DataFrame, b: DataFrame, joinColumns: Seq[String], joinType: JoinType) => 
+        HashJoiner.join(a, b, joinColumns, joinType)
+    }
+  }
+
+  /**
+   * Heuristic to decide whether to use SortMergeJoiner based on the DataFrame properties.
+   * This implementation checks if both DataFrames are sorted on the join columns.
+   *
+   * @param a The first DataFrame.
+   * @param b The second DataFrame.
+   * @param joinColumns The columns to join on.
+   * @return True if both DataFrames should use SortMergeJoiner, false otherwise.
+   */
+  private def shouldUseSortMergeJoin(a: DataFrame, b: DataFrame, joinColumns: Seq[String]): Boolean = {
+    val isASorted = isSorted(a, joinColumns)
+    val isBSorted = isSorted(b, joinColumns)
+
+    // If both DataFrames are sorted on the join columns, it's better to use SortMergeJoin
+    isASorted && isBSorted
+  }
+
+  /**
+   * Simple check to determine if a DataFrame is sorted by the join columns.
+   * This is a basic check assuming that DataFrames are sorted beforehand.
+   *
+   * @param dataFrame The DataFrame to check.
+   * @param joinColumns The columns to check for sorting.
+   * @return True if the DataFrame is sorted by the join columns, false otherwise.
+   */
+  private def isSorted(dataFrame: DataFrame, joinColumns: Seq[String]): Boolean = {
+    // Implementing a simple check: assume the DataFrame is sorted if it has more than one row and is already in sorted order.
+    // In real use cases, we can inspect the actual data or metadata to verify if it's sorted.
+    // For now, we assume it's sorted (you could enhance this check based on specific needs).
+    // In practice, this could be an optimization to check metadata or perform a fast sort check.
+    
+    // Simple heuristic: Assume it's sorted if there are less than 1000 rows, as a sample case
+    if (dataFrame.records.size < 1000) {
+      true // small DataFrame, assume it's sorted or won't matter
+    } else {
+      // For larger DataFrames, assume it's not sorted unless we know it is
+      // In production, this could be improved by checking sorting flags or inspecting the data
+      false
+    }
+  }
+}


### PR DESCRIPTION
Added two objects under the src\main\scala\org\grapheco\lynx\dataframe\

HashJoiner.scala: A HashJoiner.scala implementation based on hash join. This implementation will perform a hash join operation on two DataFrames, including supporting different join types: inner join, outer join, left join, and right join.

JoinerSelector.scala: Determines whether to use SortMergeJoiner or HashJoiner.

Modified the join method in src\main\scala\org\grapheco\lynx\dataframe\DefaultDataFrameOperator to determine the join strategy through JoinerSelector

The JoinerSelector heuristic search strategy can be further optimized later